### PR TITLE
Fix tableau noise handling and add multiplication gate support

### DIFF
--- a/sdim/circuit_io.py
+++ b/sdim/circuit_io.py
@@ -180,19 +180,27 @@ def circuit_to_cirq_circuit(circuit, measurement=False, print_circuit=False):
         # Choose the appropriate gate.
         if op.name in gate_map:
             gate = gate_map[op.name]
+        elif op.name == "MUL":
+            if op.params is None:
+                raise ValueError("Multiplication gate requires an 'a' parameter.")
+            scalar = op.params.get("a", op.params.get("scalar"))
+            if scalar is None:
+                raise ValueError("Multiplication gate requires an 'a' parameter.")
+            gate = GeneralizedMultiplicationGate(circuit.dimension, int(scalar))
             # Add the gate to the Cirq circuit.
-            if op.target_index is None:
-                # Single-qudit gate.
-                cirq_circuit.append(gate.on(qudits[op.qudit_index]))
-            else:
-                # Two-qudit gate.
-                cirq_circuit.append(gate.on(qudits[op.qudit_index], qudits[op.target_index]))
         elif op.name == "M":
             if measurement:
                 cirq_circuit.append(cirq.measure(qudits[op.qudit_index], key=f'm_{op.qudit_index}'))
             continue
         else:
             raise NotImplementedError(f"Gate {op.name} not implemented")
+
+        if op.target_index is None:
+            # Single-qudit gate.
+            cirq_circuit.append(gate.on(qudits[op.qudit_index]))
+        else:
+            # Two-qudit gate.
+            cirq_circuit.append(gate.on(qudits[op.qudit_index], qudits[op.target_index]))
     for qudit in qudits:
         if not any(op.qubits[0] == qudit for op in cirq_circuit.all_operations()):
             # Append identity to qudits with no gates

--- a/sdim/gatedata.py
+++ b/sdim/gatedata.py
@@ -48,6 +48,7 @@ class GateData:
         self.add_gate_controlled(dimension)
         self.add_gate_collapsing(dimension)
         self.add_gate_noise(dimension)
+        self.add_gate_multiplication(dimension)
 
     def __str__(self):
         return "\n".join(str(gate) for gate in self.gateMap.values())
@@ -99,12 +100,16 @@ class GateData:
     def add_gate_noise(self, d):
         self.add_gate("N1", 1)
         self.add_gate_alias("N1", ["NOISE1"])
-        self.gateMap["N1"].defaults = {"channel": "d", "prob": 0.01}
+        self.gateMap["N1"].defaults = {"noise_channel": "d", "prob": 0.01}
 
         self.add_gate("N2", 2)
         self.add_gate_alias("N2", ["NOISE2"])
         default_dist = np.ones(d ** 4) / (d ** 4)
         self.gateMap["N2"].defaults = {"prob_dist": default_dist}
+
+    def add_gate_multiplication(self, d):
+        self.add_gate("MUL", 1)
+        self.add_gate_alias("MUL", ["MULT", "MULTIPLY"])
 
     def get_gate_id(self, gate_name):
         if gate_name in self.gateMap:

--- a/sdim/program.py
+++ b/sdim/program.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple, Optional, Callable
 from .circuit import CircuitInstruction, Circuit
 from .tableau.tableau_composite import WeylTableau
@@ -28,8 +30,9 @@ GATE_FUNCTIONS: dict[int, Callable] = {
     14: apply_measure, # Measure gate in computational basis
     15: apply_measure_x, # Measure gate in X basis
     16: apply_reset, # Reset gate
-    17: apply_I, # Single qudit Pauli noise gate, implemented in Pauli frame, applied as I in noiseless reference tableau
-    18: apply_I # 2 qudit Pauli noise gate, implemented in Pauli frame, applied as I in noiseless ref.  Input is a distribution on Pauli operators, shape is (d, d, d, d)
+    17: apply_single_qudit_noise, # Single qudit Pauli noise gate
+    18: apply_two_qudit_noise, # 2 qudit Pauli noise gate, input is a distribution on Pauli operators, shape is (d, d, d, d)
+    19: apply_multiplication, # Multiplication gate
 }
 
 MEASUREMENT_DTYPE = np.dtype([
@@ -77,6 +80,7 @@ def simulate_frame(ir_array: np.ndarray, reference_results: np.ndarray,
         gate_id = inst['gate_id']
         qudit_index = inst['qudit_index']
         target_index = inst['target_index']
+        scalar = inst['scalar']
         if gate_count % 64 == 0:
             x_frame %= dimension
             z_frame %= dimension
@@ -168,6 +172,11 @@ def simulate_frame(ir_array: np.ndarray, reference_results: np.ndarray,
             x_frame[target_index] += noise_array[noise_counter, :, 2]
             z_frame[target_index] += noise_array[noise_counter, :, 3]
             noise_counter += 1
+        elif gate_id == 19:  # Multiplication gate
+            scalar = int(scalar) % dimension
+            inverse = pow(scalar, -1, dimension)
+            x_frame[qudit_index] *= scalar
+            z_frame[qudit_index] *= inverse
 
         gate_count += 1
         
@@ -214,6 +223,7 @@ class Program:
         self.circuits = [circuit]
         self.measurement_results = []
         self.initial_tableau = copy.copy(self.stabilizer_tableau)
+        self._tableau_noise_enabled = True
 
     def simulate(self, shots: int = 1, show_measurement: bool = False, record_tableau: bool = False, force_tableau: bool = False,
                  verbose: bool = False, show_gate: bool = False, exact: bool = False, options: SimulationOptions = None) -> list[list[list[MeasurementResult]]]:
@@ -256,7 +266,11 @@ class Program:
         if options.shots > 1 and not options.record_tableau and not options.force_tableau:
             tableau_options = copy.copy(options)
             tableau_options.shots = 1
-            self._simulate_tableau(tableau_options)
+            self._tableau_noise_enabled = False
+            try:
+                self._simulate_tableau(tableau_options)
+            finally:
+                self._tableau_noise_enabled = True
             
             # Convert flattened reference results to structured array
             ref_array = self._results_to_array(self.measurement_results)
@@ -392,6 +406,8 @@ class Program:
         """
         if instruc.gate_id not in GATE_FUNCTIONS:
             raise ValueError("Invalid gate value")
+        if not self._tableau_noise_enabled and instruc.gate_id in (17, 18):
+            return None
         gate_function = GATE_FUNCTIONS[instruc.gate_id]
         measurement_result = gate_function(self.stabilizer_tableau, instruc.qudit_index, instruc.target_index, instruc.params)
         return measurement_result
@@ -478,7 +494,7 @@ class Program:
         Returns:
             tuple:
                 - A NumPy array of IR instructions with each element as a tuple
-                (gate_id, qudit_index, target_index).
+                (gate_id, qudit_index, target_index, scalar).
                 - A NumPy array of shape (num_noise_gates, extra_shots, [x_block, z_block]) containing
                 pre-sampled noise outcomes for each noise gate encountered.
                 If no noise gate is present, an empty array is returned.
@@ -491,11 +507,20 @@ class Program:
                 if instruction.gate_id == 0:
                     continue
                 target_index = instruction.target_index if instruction.target_index is not None else -1
-                ir_list.append((instruction.gate_id, instruction.qudit_index, target_index))
+                scalar = -1
+                if instruction.gate_id == 19:
+                    if instruction.params is None:
+                        raise ValueError("Multiplication gate requires an 'a' parameter.")
+                    scalar = instruction.params.get('a', instruction.params.get('scalar'))
+                    if scalar is None:
+                        raise ValueError("Multiplication gate requires an 'a' parameter.")
+                    scalar = int(scalar)
+
+                ir_list.append((instruction.gate_id, instruction.qudit_index, target_index, scalar))
                                 
                 if instruction.gate_id == 17:
                     # Always add a noise sample, but only actually sample non-identity with some probability.
-                    channel = instruction.params['noise_channel']
+                    channel = instruction.params.get('noise_channel', instruction.params.get('channel', 'd'))
                     if channel == 'd':
                         # Sample integer r from 1 to dimension**2 - 1 for each extra shot.
                         r = np.random.randint(1, dimension**2, size=extra_shots)
@@ -537,7 +562,8 @@ class Program:
         ir_dtype = np.dtype([
             ('gate_id', np.int64),
             ('qudit_index', np.int64),
-            ('target_index', np.int64)
+            ('target_index', np.int64),
+            ('scalar', np.int64)
         ])
 
         ir_array = np.array(ir_list, dtype=ir_dtype)

--- a/sdim/tableau/tableau_gates.py
+++ b/sdim/tableau/tableau_gates.py
@@ -24,6 +24,24 @@ def apply_I(tableau: Tableau, qudit_index: int, *_) -> None:
     """
     return None
 
+def _apply_pauli_powers(tableau: Tableau, qudit_index: int, x_exp: int, z_exp: int) -> None:
+    """
+    Apply X and Z powers to a single qudit.
+    """
+    x_exp %= tableau.dimension
+    z_exp %= tableau.dimension
+
+    for _ in range(x_exp):
+        apply_X(tableau=tableau, qudit_index=qudit_index)
+    for _ in range(z_exp):
+        apply_Z(tableau=tableau, qudit_index=qudit_index)
+
+def _get_noise_channel(params: dict) -> str:
+    """
+    Normalize the user-facing noise channel parameter name.
+    """
+    return params.get('noise_channel', params.get('channel', 'd'))
+
 def apply_X(tableau: Tableau, qudit_index: int, *_) -> None:
     """
     Apply Pauli X gate.
@@ -345,7 +363,26 @@ def apply_reset(tableau: Tableau, qudit_index: int, *_) -> Optional[MeasurementR
     else:
         return tableau.measure(qudit_index)
     
+def apply_multiplication(tableau: Tableau, qudit_index: int, _, params: dict) -> None:
+    """
+    Apply a multiplicative Clifford gate to a qudit.
 
+    Args:
+        tableau (Tableau): The quantum tableau.
+        qudit_index (int): The qudit on which to act.
+        _ : Unused target index.
+        params (dict): Must contain either ``a`` or ``scalar``.
+    """
+    if params is None:
+        raise ValueError("Multiplication gate requires a scalar parameter.")
+
+    scalar = params.get('a', params.get('scalar'))
+    if scalar is None:
+        raise ValueError("Multiplication gate requires an 'a' parameter.")
+
+    tableau.multiply(qudit_index, int(scalar))
+    return None
+    
 def apply_single_qudit_noise(tableau : Tableau, qudit_index: int, _, params: dict) -> None:
     """
     DEPRECIATED -- Noise behavior is handled in program.py in Pauli frames.  This gate definition is nonetheless included for the sake of documentation and completeness.
@@ -371,7 +408,7 @@ def apply_single_qudit_noise(tableau : Tableau, qudit_index: int, _, params: dic
         None  
     """
     prob = float(params.get('prob', 0.5))
-    noise_channel = params.get('noise_channel', 'd')
+    noise_channel = _get_noise_channel(params)
 
     if noise_channel == 'd':
         num = random.uniform(0.0, 1.0)
@@ -380,16 +417,11 @@ def apply_single_qudit_noise(tableau : Tableau, qudit_index: int, _, params: dic
             return None
         
         # Sample error from all non-identity Pauli gates 
-        elem = random.randint(1, tableau.dimension - 1)
+        elem = random.randint(1, tableau.dimension ** 2 - 1)
         x_exp = elem % tableau.dimension
         z_exp = elem // tableau.dimension
 
-        # Apply the Pauli gates.  Order does not matter up to phase since measurement statistics are identical.
-        for _ in range(x_exp):
-            apply_X(tableau=tableau, qudit_index=qudit_index)
-        for _ in range(z_exp):
-            apply_Z(tableau=tableau, qudit_index=qudit_index)
-
+        _apply_pauli_powers(tableau, qudit_index, x_exp, z_exp)
         return None
     
     elif noise_channel == 'f' or noise_channel == 'p':
@@ -402,15 +434,32 @@ def apply_single_qudit_noise(tableau : Tableau, qudit_index: int, _, params: dic
         op_exp = random.randint(1, tableau.dimension - 1)
         # Apply appropriate error
         if flip:
-            for _ in range(op_exp):
-                apply_X(tableau=tableau, qudit_index=qudit_index)
+            _apply_pauli_powers(tableau, qudit_index, op_exp, 0)
         else:
-            for _ in range(op_exp):
-                apply_Z(tableau=tableau, qudit_index=qudit_index)
+            _apply_pauli_powers(tableau, qudit_index, 0, op_exp)
         
         return None
     
 
     raise ValueError("Must specify a valid noise channel.")
-    
+
+def apply_two_qudit_noise(tableau: Tableau, qudit_index: int, target_index: int, params: dict) -> None:
+    """
+    Sample and apply a two-qudit Pauli noise event.
+    """
+    if params is None or 'prob_dist' not in params:
+        raise ValueError("Two-qudit noise requires a 'prob_dist' parameter.")
+
+    distribution = np.asarray(params['prob_dist'], dtype=float).reshape(-1)
+    required_length = tableau.dimension ** 4
+    if distribution.size != required_length:
+        raise ValueError(
+            f"Input distribution has length {distribution.size} instead of the required {required_length}."
+        )
+
+    noise_index = np.random.choice(required_length, p=distribution)
+    x_1, z_1, x_2, z_2 = np.unravel_index(noise_index, (tableau.dimension,) * 4)
+    _apply_pauli_powers(tableau, qudit_index, int(x_1), int(z_1))
+    _apply_pauli_powers(tableau, target_index, int(x_2), int(z_2))
+    return None
 

--- a/sdim/tableau/tableau_prime.py
+++ b/sdim/tableau/tableau_prime.py
@@ -258,6 +258,23 @@ class ExtendedTableau(Tableau):
         cnot_inv_optimized(self.x_block, self.z_block, self.destab_x_block, self.destab_z_block,
                        self.num_qudits, self.dimension,
                        control, target)
+
+    def multiply(self, qudit_index: int, scalar: int):
+        """
+        Apply a multiplicative Clifford gate to the specified qudit.
+
+        Args:
+            qudit_index (int): Index of the qudit.
+            scalar (int): Multiplicative factor modulo the qudit dimension.
+        """
+        if scalar not in self.coprime_dimension:
+            raise ValueError(f"Scalar {scalar} is not coprime with the dimension {self.dimension}.")
+
+        inverse = pow(scalar, -1, self.dimension)
+        self.z_block[qudit_index, :] = (self.z_block[qudit_index, :] * inverse) % self.dimension
+        self.x_block[qudit_index, :] = (self.x_block[qudit_index, :] * scalar) % self.dimension
+        self.destab_z_block[qudit_index, :] = (self.destab_z_block[qudit_index, :] * inverse) % self.dimension
+        self.destab_x_block[qudit_index, :] = (self.destab_x_block[qudit_index, :] * scalar) % self.dimension
             
     def measure(self, qudit_index: int) -> MeasurementResult:
         """

--- a/sdim/unitary.py
+++ b/sdim/unitary.py
@@ -218,6 +218,30 @@ class GeneralizedPhaseShiftGateInverse(cirq.Gate):
     def _circuit_diagram_info_(self, args):
         return f"P_{self.d}†"
 
+class GeneralizedMultiplicationGate(cirq.Gate):
+    def __init__(self, d, a):
+        super(GeneralizedMultiplicationGate, self).__init__()
+        self.d = d
+        self.a = a
+
+    def _qid_shape_(self):
+        return (self.d,)
+
+    def _unitary_(self):
+        return generate_m_matrix(self.d, self.a)
+
+    def __pow__(self, exponent):
+        if exponent == 0:
+            return IdentityGate(self.d)
+        if exponent == 1:
+            return self
+        if exponent == -1:
+            return GeneralizedMultiplicationGate(self.d, pow(self.a, -1, self.d))
+        return NotImplemented
+
+    def _circuit_diagram_info_(self, args):
+        return f"MUL_{self.a}"
+
 class GeneralizedXPauliGate(cirq.Gate):
     def __init__(self, d):
         super(GeneralizedXPauliGate, self).__init__()

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -113,7 +113,8 @@ def test_build_ir():
     ir_dtype = np.dtype([
         ('gate_id', np.int64),
         ('qudit_index', np.int64),
-        ('target_index', np.int64)
+        ('target_index', np.int64),
+        ('scalar', np.int64)
     ])
     c = Circuit(dimension=3, num_qudits=2)
     c.add_gate("H", 0)
@@ -122,30 +123,69 @@ def test_build_ir():
     p = Program(c)
     extra_shots = 1
     ir, noise = p._build_ir(p.circuits, extra_shots)
-    test_ir = np.array([(5, 0, -1), (9, 0, 1), (14, 0, -1), (14, 1, -1)], dtype=ir_dtype)
+    test_ir = np.array([(5, 0, -1, -1), (9, 0, 1, -1), (14, 0, -1, -1), (14, 1, -1, -1)], dtype=ir_dtype)
     np.testing.assert_array_equal(ir, test_ir)
 
     ir, noise = p._build_ir(p.circuits, extra_shots+1)
-    test_ir = np.array([(5, 0, -1), (9, 0, 1), (14, 0, -1), (14, 1, -1)], dtype=ir_dtype)
+    test_ir = np.array([(5, 0, -1, -1), (9, 0, 1, -1), (14, 0, -1, -1), (14, 1, -1, -1)], dtype=ir_dtype)
     np.testing.assert_array_equal(ir, test_ir)
 
     c.add_gate("N1", 0, prob=1.0, noise_channel='f')
     ir, noise = p._build_ir(p.circuits, extra_shots)
-    test_ir = np.array([(5, 0, -1), (9, 0, 1), (14, 0, -1), (14, 1, -1), (17, 0, -1)], dtype=ir_dtype)
+    test_ir = np.array([(5, 0, -1, -1), (9, 0, 1, -1), (14, 0, -1, -1), (14, 1, -1, -1), (17, 0, -1, -1)], dtype=ir_dtype)
     np.testing.assert_array_equal(ir, test_ir)
     assert np.any(noise[0][0][0])
 
     c.add_gate("N1", 1, prob=1.0, noise_channel='p')
     ir, noise = p._build_ir(p.circuits, extra_shots)
-    test_ir = np.array([(5, 0, -1), (9, 0, 1), (14, 0, -1), (14, 1, -1), (17, 0, -1), (17, 1, -1)], dtype=ir_dtype)
+    test_ir = np.array([(5, 0, -1, -1), (9, 0, 1, -1), (14, 0, -1, -1), (14, 1, -1, -1), (17, 0, -1, -1), (17, 1, -1, -1)], dtype=ir_dtype)
     np.testing.assert_array_equal(ir, test_ir)
     assert np.any(noise[1][0][1])
 
     c.add_gate("N1", 1, prob=1.0, noise_channel='d')
     ir, noise = p._build_ir(p.circuits, extra_shots)
-    test_ir = np.array([(5, 0, -1), (9, 0, 1), (14, 0, -1), (14, 1, -1), (17, 0, -1), (17, 1, -1), (17, 1, -1)], dtype=ir_dtype)
+    test_ir = np.array([(5, 0, -1, -1), (9, 0, 1, -1), (14, 0, -1, -1), (14, 1, -1, -1), (17, 0, -1, -1), (17, 1, -1, -1), (17, 1, -1, -1)], dtype=ir_dtype)
     np.testing.assert_array_equal(ir, test_ir)
     assert np.any(noise[2][0])
+
+    c.add_gate("MUL", 0, a=2)
+    ir, noise = p._build_ir(p.circuits, extra_shots)
+    test_ir = np.array([(5, 0, -1, -1), (9, 0, 1, -1), (14, 0, -1, -1), (14, 1, -1, -1), (17, 0, -1, -1), (17, 1, -1, -1), (17, 1, -1, -1), (19, 0, -1, 2)], dtype=ir_dtype)
+    np.testing.assert_array_equal(ir, test_ir)
+
+@pytest.mark.parametrize(("dimension", "scalar"), [(4, 3), (5, 2)])
+def test_multiplication_gate_simulation(dimension, scalar):
+    circuit = Circuit(dimension=dimension, num_qudits=1)
+    circuit.add_gate("X", 0)
+    circuit.add_gate("MUL", 0, a=scalar)
+    circuit.add_gate("M", 0)
+
+    result = Program(circuit).simulate()
+    assert result == [MeasurementResult(0, True, scalar % dimension)]
+
+def test_tableau_noise_gate_is_not_replaced_by_identity():
+    circuit = Circuit(dimension=5, num_qudits=1)
+    circuit.add_gate("N1", 0, prob=1.0, noise_channel='f')
+    circuit.add_gate("M", 0)
+
+    result = Program(circuit).simulate(shots=6, force_tableau=True)
+    measured_values = [shot.measurement_value for shot in result[0][0]]
+
+    assert all(value != 0 for value in measured_values)
+
+def test_two_qudit_tableau_noise_gate_is_not_replaced_by_identity():
+    distribution = np.zeros(3 ** 4)
+    distribution[3 ** 3] = 1.0  # (x1, z1, x2, z2) = (1, 0, 0, 0)
+
+    circuit = Circuit(dimension=3, num_qudits=2)
+    circuit.add_gate("N2", 0, 1, prob_dist=distribution)
+    circuit.add_gate("M", 0)
+    circuit.add_gate("M", 1)
+
+    result = Program(circuit).simulate(shots=3, force_tableau=True)
+
+    assert all(shot.measurement_value == 1 for shot in result[0][0])
+    assert all(shot.measurement_value == 0 for shot in result[1][0])
 
    
 


### PR DESCRIPTION
Putting this up because Adeeb asked me to submit these bug fixes.

This fixes the tableau noise issue so the noise gates are no longer treated like identity in the reference path, and it adds multiplication gate support across the IR, tableau, and Cirq paths.

I also added tests covering the IR updates, multiplication gate simulation, and the tableau noise cases.

